### PR TITLE
Fix:host

### DIFF
--- a/packages/sns-api-2/.env
+++ b/packages/sns-api-2/.env
@@ -1,1 +1,1 @@
-DATABASE_URL="postgresql://root:password@0.0.0.0:5433/app-db?schema=public"
+DATABASE_URL="postgresql://root:password@127.0.0.1:5433/app-db?schema=public"


### PR DESCRIPTION
to fix the error as follows

```
> sns-api-2@0.1.0 db-migrate-dev
> prisma migrate dev

Environment variables loaded from .env
Prisma schema loaded from prisma\schema.prisma
Datasource "db": PostgreSQL database "app-db", schema "public" at "0.0.0.0:5433"

Error: P1001: Can't reach database server at `0.0.0.0`:`5433`

Please make sure your database server is running at `0.0.0.0`:`5433`.
```